### PR TITLE
create_function deprecated, removed in PHP 8

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -216,8 +216,7 @@ add_filter( 'get_search_form', 'bugis_search_form' );
 /*-----------------------------------------------------------------------------------*/
 /*  Removes the default CSS style from the WP image gallery
 /*-----------------------------------------------------------------------------------*/
-add_filter('gallery_style', create_function('$a', 'return "
-<div class=\'gallery\'>";'));
+add_filter('gallery_style', function($a) { return "<div class=\'gallery\'>"; } );
 
 
 /*-----------------------------------------------------------------------------------*/


### PR DESCRIPTION
Hello! My server upgraded from PHP 7.4 to PHP 8 and I realized that my Bugis theme no longer worked since create_function was deprecated and removed. I'm not sure if there might be any other code changes that would prevent Bugis from working, but fixing this one line got my installation working again. Thanks for a great template!